### PR TITLE
feat: export engine and finalize gnolang refactor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 gnoswap-labs
+Copyright (c) 2024 gnolang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Advance Linter for go-like grammar languages.
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/gnoswap-labs/tlin/CI?label=build)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/gnolang/tlin/CI?label=build)
 ![License](https://img.shields.io/badge/License-MIT-blue.svg)
 
 ## Introduction
@@ -31,7 +31,7 @@ To install tlin CLI, follow these steps:
 1. Clone the repository
 
 ```bash
-git clone https://github.com/gnoswap-labs/tlin
+git clone https://github.com/gnolang/tlin
 ```
 
 2. Move to the cloned directory

--- a/cmd/tlin/main.go
+++ b/cmd/tlin/main.go
@@ -50,7 +50,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 	defer cancel()
 
-	engine, err := internal.NewEngine(".", nil)
+	engine, err := lint.New(".", nil)
 	if err != nil {
 		logger.Fatal("Failed to initialize lint engine", zap.Error(err))
 	}

--- a/cmd/tlin/main.go
+++ b/cmd/tlin/main.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gnoswap-labs/tlin/formatter"
-	"github.com/gnoswap-labs/tlin/internal"
-	"github.com/gnoswap-labs/tlin/internal/analysis/cfg"
-	"github.com/gnoswap-labs/tlin/internal/fixer"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
-	"github.com/gnoswap-labs/tlin/lint"
+	"github.com/gnolang/tlin/formatter"
+	"github.com/gnolang/tlin/internal"
+	"github.com/gnolang/tlin/internal/analysis/cfg"
+	"github.com/gnolang/tlin/internal/fixer"
+	tt "github.com/gnolang/tlin/internal/types"
+	"github.com/gnolang/tlin/lint"
 	"go.uber.org/zap"
 )
 

--- a/cmd/tlin/main_test.go
+++ b/cmd/tlin/main_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"

--- a/formatter/builder.go
+++ b/formatter/builder.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 // rule set

--- a/formatter/cyclomatic_complexity.go
+++ b/formatter/cyclomatic_complexity.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type CyclomaticComplexityFormatter struct{}

--- a/formatter/defers.go
+++ b/formatter/defers.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type DefersFormatter struct{}

--- a/formatter/early_return.go
+++ b/formatter/early_return.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type EarlyReturnOpportunityFormatter struct{}

--- a/formatter/format_emit.go
+++ b/formatter/format_emit.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type EmitFormatFormatter struct{}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -4,8 +4,8 @@ import (
 	"go/token"
 	"testing"
 
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/formatter/general.go
+++ b/formatter/general.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 // GeneralIssueFormatter is a formatter for general lint issues.

--- a/formatter/missing_mod_pacakge.go
+++ b/formatter/missing_mod_pacakge.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type MissingModPackageFormatter struct{}

--- a/formatter/simplify_slice_expr.go
+++ b/formatter/simplify_slice_expr.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type SimplifySliceExpressionFormatter struct{}

--- a/formatter/slice_bound.go
+++ b/formatter/slice_bound.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type SliceBoundsCheckFormatter struct{}

--- a/formatter/unnecessary_type_conv.go
+++ b/formatter/unnecessary_type_conv.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"github.com/gnoswap-labs/tlin/internal"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type UnnecessaryTypeConversionFormatter struct{}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gnoswap-labs/tlin
+module github.com/gnolang/tlin
 
 go 1.22.2
 

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/gnoswap-labs/tlin/internal/lints"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal/lints"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 // Engine manages the linting process.

--- a/internal/engine_test.go
+++ b/internal/engine_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type Fixer struct {

--- a/internal/fixer/fixer_test.go
+++ b/internal/fixer/fixer_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/lints/cyclomatic_complexity.go
+++ b/internal/lints/cyclomatic_complexity.go
@@ -7,7 +7,7 @@ import (
 	"go/token"
 
 	"github.com/fzipp/gocyclo"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 func DetectHighCyclomaticComplexity(filename string, threshold int) ([]tt.Issue, error) {

--- a/internal/lints/default_golangci.go
+++ b/internal/lints/default_golangci.go
@@ -8,7 +8,7 @@ import (
 	"go/token"
 	"os/exec"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 func ParseFile(filename string, content []byte) (*ast.File, *token.FileSet, error) {

--- a/internal/lints/defers.go
+++ b/internal/lints/defers.go
@@ -4,7 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 type DeferChecker struct {

--- a/internal/lints/detect_cycles.go
+++ b/internal/lints/detect_cycles.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 func DetectCycle(filename string, node *ast.File, fset *token.FileSet) ([]tt.Issue, error) {

--- a/internal/lints/early_return.go
+++ b/internal/lints/early_return.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gnoswap-labs/tlin/internal/branch"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal/branch"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 // DetectEarlyReturnOpportunities detects if-else chains that can be simplified using early returns.

--- a/internal/lints/format_emit.go
+++ b/internal/lints/format_emit.go
@@ -5,7 +5,7 @@ import (
 	"go/token"
 	"strings"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 func DetectEmitFormat(filename string, node *ast.File, fset *token.FileSet) ([]tt.Issue, error) {

--- a/internal/lints/gno_analyzer.go
+++ b/internal/lints/gno_analyzer.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 const (

--- a/internal/lints/loop_allocation.go
+++ b/internal/lints/loop_allocation.go
@@ -4,7 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 func DetectLoopAllocation(filename string, node *ast.File, fset *token.FileSet) ([]tt.Issue, error) {

--- a/internal/lints/missing_package_mod.go
+++ b/internal/lints/missing_package_mod.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 func DetectMissingModPackage(filename string, node *ast.File, fset *token.FileSet) ([]tt.Issue, error) {

--- a/internal/lints/repeated_regex_compilation.go
+++ b/internal/lints/repeated_regex_compilation.go
@@ -4,7 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/packages"
 )

--- a/internal/lints/simplify_slice_expr.go
+++ b/internal/lints/simplify_slice_expr.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 func DetectUnnecessarySliceLength(filename string, node *ast.File, fset *token.FileSet) ([]tt.Issue, error) {

--- a/internal/lints/slice_bound.go
+++ b/internal/lints/slice_bound.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 // TODO: Make more precisely.

--- a/internal/lints/unncessary_type_conversion.go
+++ b/internal/lints/unncessary_type_conversion.go
@@ -7,7 +7,7 @@ import (
 	"go/token"
 	"go/types"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 func DetectUnnecessaryConversions(filename string, node *ast.File, fset *token.FileSet) ([]tt.Issue, error) {

--- a/internal/lints/useless_break.go
+++ b/internal/lints/useless_break.go
@@ -4,7 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 // DetectUselessBreak detects useless break statements in switch or select statements.

--- a/internal/rule_set.go
+++ b/internal/rule_set.go
@@ -4,8 +4,8 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/gnoswap-labs/tlin/internal/lints"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal/lints"
+	tt "github.com/gnolang/tlin/internal/types"
 )
 
 /*

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -19,7 +19,7 @@ type LintEngine interface {
 }
 
 // export the function NewEngine to be used in other packages
-func NewEngine(rootDir string, source []byte) (*internal.Engine, error) {
+func New(rootDir string, source []byte) (*internal.Engine, error) {
 	return internal.NewEngine(rootDir, source)
 }
 

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gnoswap-labs/tlin/internal"
 	"github.com/gnoswap-labs/tlin/internal/lints"
 	tt "github.com/gnoswap-labs/tlin/internal/types"
 	"go.uber.org/zap"
@@ -15,6 +16,11 @@ type LintEngine interface {
 	Run(filePath string) ([]tt.Issue, error)
 	RunSource(source []byte) ([]tt.Issue, error)
 	IgnoreRule(rule string)
+}
+
+// export the function NewEngine to be used in other packages
+func NewEngine(rootDir string, source []byte) (*internal.Engine, error) {
+	return internal.NewEngine(rootDir, source)
 }
 
 func ProcessSources(ctx context.Context, logger *zap.Logger, engine LintEngine, sources [][]byte, processor func(LintEngine, []byte) ([]tt.Issue, error)) ([]tt.Issue, error) {

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gnoswap-labs/tlin/internal"
-	"github.com/gnoswap-labs/tlin/internal/lints"
-	tt "github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal"
+	"github.com/gnolang/tlin/internal/lints"
+	tt "github.com/gnolang/tlin/internal/types"
 	"go.uber.org/zap"
 )
 

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gnoswap-labs/tlin/internal/types"
+	"github.com/gnolang/tlin/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"


### PR DESCRIPTION
This PR export the function to create the engine and refactor the remaining of gnoswap-labs to replace it by gnolang