### PR TITLE
perf(fixer): enhance auto fix

### DIFF
--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -13,11 +13,18 @@ import (
 	tt "github.com/gnolang/tlin/internal/types"
 )
 
+const (
+	defaultFilePermissions = 0o644
+)
+
+// Fixer handles the fixing of issues in Gno code files.
 type Fixer struct {
 	DryRun        bool
-	MinConfidence float64 // threshold for fixing issues
+	MinConfidence float64
+	buffer        bytes.Buffer
 }
 
+// New creates a new Fixer instance.
 func New(dryRun bool, threshold float64) *Fixer {
 	return &Fixer{
 		DryRun:        dryRun,
@@ -25,17 +32,15 @@ func New(dryRun bool, threshold float64) *Fixer {
 	}
 }
 
+// Fix applies fixes to the given file based on the provided issues.
 func (f *Fixer) Fix(filename string, issues []tt.Issue) error {
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %w", err)
 	}
 
-	sort.Slice(issues, func(i, j int) bool {
-		return issues[i].End.Offset > issues[j].End.Offset
-	})
-
 	lines := strings.Split(string(content), "\n")
+	sortIssuesByEndOffset(issues)
 
 	for _, issue := range issues {
 		if issue.Confidence < f.MinConfidence {
@@ -43,70 +48,96 @@ func (f *Fixer) Fix(filename string, issues []tt.Issue) error {
 		}
 
 		if f.DryRun {
-			fmt.Printf("Would fix issue in %s at line %d: %s\n", filename, issue.Start.Line, issue.Message)
-			fmt.Printf("Suggestion:\n%s\n", issue.Suggestion)
+			f.printDryRunInfo(filename, issue)
 			continue
 		}
 
-		startLine := issue.Start.Line - 1
-		endLine := issue.End.Line - 1
-
-		indent := f.extractIndent(lines[startLine])
-		suggestion := applyIndent(issue.Suggestion, indent, issue.Start)
-
-		lines = append(lines[:startLine], append([]string{suggestion}, lines[endLine+1:]...)...)
+		lines = f.applyFix(lines, issue)
 	}
 
 	if !f.DryRun {
-		newContent := strings.Join(lines, "\n")
-
-		fset := token.NewFileSet()
-		astFile, err := parser.ParseFile(fset, filename, newContent, parser.ParseComments)
-		if err != nil {
-			return fmt.Errorf("failed to parse file: %w", err)
+		if err := f.writeFixedContent(filename, lines); err != nil {
+			return err
 		}
-
-		var buf bytes.Buffer
-		if err := format.Node(&buf, fset, astFile); err != nil {
-			return fmt.Errorf("failed to format file: %w", err)
-		}
-
-		err = os.WriteFile(filename, buf.Bytes(), 0o644)
-		if err != nil {
-			return fmt.Errorf("failed to write file: %w", err)
-		}
-
 		fmt.Printf("Fixed issues in %s\n", filename)
 	}
 
 	return nil
 }
 
-func (f *Fixer) extractIndent(line string) string {
+func (f *Fixer) printDryRunInfo(filename string, issue tt.Issue) {
+	fmt.Printf("Would fix issue in %s at line %d: %s\n", filename, issue.Start.Line, issue.Message)
+	fmt.Printf("Suggestion:\n%s\n", issue.Suggestion)
+}
+
+func (f *Fixer) applyFix(lines []string, issue tt.Issue) []string {
+	startLine := issue.Start.Line - 1
+	endLine := issue.End.Line - 1
+
+	indent := extractIndent(lines[startLine])
+	suggestion := applyIndent(issue.Suggestion, indent, issue.Start)
+
+	return append(lines[:startLine], append([]string{suggestion}, lines[endLine+1:]...)...)
+}
+
+func (f *Fixer) writeFixedContent(filename string, lines []string) error {
+	f.buffer.Reset()
+	for i, line := range lines {
+		f.buffer.WriteString(line)
+		if i < len(lines)-1 {
+			f.buffer.WriteByte('\n')
+		}
+	}
+
+	fset := token.NewFileSet()
+	astFile, err := parser.ParseFile(fset, filename, f.buffer.Bytes(), parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("failed to parse file: %w", err)
+	}
+
+	f.buffer.Reset()
+	if err := format.Node(&f.buffer, fset, astFile); err != nil {
+		return fmt.Errorf("failed to format file: %w", err)
+	}
+
+	if err := os.WriteFile(filename, f.buffer.Bytes(), defaultFilePermissions); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}
+
+// sorts the issues by the end offset of the issue.
+// By doing this, we ensure that the issues are applied in the correct order.
+func sortIssuesByEndOffset(issues []tt.Issue) {
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].End.Offset > issues[j].End.Offset
+	})
+}
+
+// extractIndent extracts the indentation from the first line of the issue.
+func extractIndent(line string) string {
 	return line[:len(line)-len(strings.TrimLeft(line, " \t"))]
 }
 
-func applyIndent(content, suggestion string, start token.Position) string {
+// applyIndent applies the indentation to the suggestion.
+func applyIndent(content, indent string, start token.Position) string {
 	lines := strings.Split(content, "\n")
-	sugLines := strings.Split(suggestion, "\n")
+	sugLines := strings.Split(indent, "\n")
 	offset := getOffset(lines, start.Line-1)
 
-	// apply the offset to all suggestion lines
 	for i := range sugLines {
 		sugLines[i] = strings.Repeat(" ", offset) + sugLines[i]
 	}
 
-	// replace the lines in the original content
-	for i := 0; i < len(sugLines); i++ {
-		if start.Line-1+i < len(lines) {
-			lines[start.Line-1+i] = sugLines[i]
-		}
+	for i := 0; i < len(sugLines) && start.Line-1+i < len(lines); i++ {
+		lines[start.Line-1+i] = sugLines[i]
 	}
 
 	return strings.Join(lines, "\n")
 }
 
-// get the offset (indentation) of a line
+// getOffset calculates the offset of the indentation from the first line of the issue.
 func getOffset(lines []string, lineIndex int) int {
 	if lineIndex < 0 || lineIndex >= len(lines) {
 		return 0


### PR DESCRIPTION
# Description

Improve performance and memory usage in Fixer

```plain
old version:    9111        113605 ns/op        7812 B/op         138 allocs/op
new version:  10000        104953 ns/op        7317 B/op         133 allocs/op
```

- Execution time: 7.6% faster (104953 ns/op vs 113605 ns/op)
- Memory allocation: 6.3% reduction (7317 B/op vs 7812 B/op)
- Allocation count: 3.6% fewer allocations (133 allocs/op vs 138 allocs/op)